### PR TITLE
2020-10-09 백준

### DIFF
--- a/AlgoRepo_3/백준_2 x n 타일링 2.cpp
+++ b/AlgoRepo_3/백준_2 x n 타일링 2.cpp
@@ -1,0 +1,21 @@
+#include <cstdio>
+
+using namespace std;
+
+int dp[1001];
+
+int main()
+{
+    int n;
+    scanf("%d", &n);
+
+    dp[1] = 1;
+    dp[2] = 3;
+
+    for(int i = 3; i <= n; i++)
+    {
+        dp[i] = (dp[i - 1] + dp[i - 2] * 2) % 10007;
+    }
+
+    printf("%d", dp[n]);
+}


### PR DESCRIPTION
- 백준_2 x n 타일링 2

DP에 대한 연습을 하기위해 푼 문제입니다.
Bottom-Up 방식으로 처음부터 모양을 그려가면서 규칙을 찾으려고 했지만 오히려 잘 보이지 않았고 오히려 뒤에서 부터 규칙을 찾을 수 있던 문제였습니다.

해당 문제에 대한 링크입니다.
- 2 x n 타일링 2
https://www.acmicpc.net/problem/11727